### PR TITLE
LXD test env: playbooks, README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Ignore Ansible retry files
+*.retry

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# ansible-playbooks
-Various Ansible Playbooks that I'm testing. I'm a complete newbie, so likely nothing worth seeing here.
+# Ansible Playbooks
+
+## `lxd-testenv`
+
+Small suite of playbooks intended to help quickly spin up a test environment
+for other playbook work.
+
+See the [README](lxd-testenv/README.md) for more info.

--- a/lxd-testenv/README.md
+++ b/lxd-testenv/README.md
@@ -1,0 +1,47 @@
+# lxd-testenv playbook
+
+*Small suite of playbooks intended to help quickly spin up a test environment
+for other playbook work.*
+
+## Prerequisites
+
+The following items need to be completed *before* attempting to use the
+playbook.
+
+### Generate SSH Public key
+
+`ssh-keygen -t ed25519`
+
+Press Enter repeatedly until the process completes. The new key should ONLY be
+used for accessing containers on the test LXD host system.
+
+### Install packages
+
+`sudo apt-get install lxd lxd-client`
+
+### Initial setup
+
+The `ansible-lxd.yml` playbook requires that you first install the LXD
+daemon and client packages. After that, run `sudo lxd init`.
+
+Be sure to use NAT, DHCP and setup a bridge network device (NAT).
+
+**Note:** This held true as of LXD 2.0. I have not tested 2.5+ sufficiently
+to know what additional steps are needed to safely setup LXD for local testing.
+
+## Using the `lxd-*.yml` playbooks
+
+### Create new test environment
+
+1. `ansible-playbook -i hosts lxd-setup-containers.yml -K`
+1. `ansible-playbook -i hosts lxd-setup-host.yml -K`
+
+### Teardown test environment
+
+`ansible-playbook -i hosts lxd-remove.yml -K`
+
+## References
+
+- [Generate /etc/hosts with Ansible](https://gist.github.com/rothgar/8793800)
+- <https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html>
+- <https://stackoverflow.com/questions/30226113/ansible-ssh-prompt-known-hosts-issue>

--- a/lxd-testenv/hosts
+++ b/lxd-testenv/hosts
@@ -1,0 +1,45 @@
+# vim: ts=4:sw=4:et:ft=ini
+# -*- mode: ini; indent-tabs-mode: nil; tab-width: 4 -*-
+# code: language=ini insertSpaces=true tabSize=4
+
+# Inventory file for Ansible testing purposes
+
+# Hosts HAVE to be included in one of the OS groups in order to be
+# spun up as a LXD container.
+
+[centos]
+
+ansible-centos-1
+ansible-centos-2
+ansible-centos-3
+ansible-centos-4
+ansible-centos-5
+ansible-centos-6
+ansible-centos-7
+ansible-centos-8
+
+[ubuntu]
+
+ansible-ubuntu-9
+ansible-ubuntu-10
+ansible-ubuntu-11
+ansible-ubuntu-12
+ansible-ubuntu-13
+
+
+[all:vars]
+
+# Everything in this inventory is a LXD container, so make sure Ansible only
+# uses that means of establishing a connection.
+ansible_connection = lxd
+
+# lxd does not support remote_user (i.e., this setting) and defaults to 'root'
+ansible_user = root
+
+# Defines what container image is used
+[ubuntu:vars]
+source = ubuntu/xenial/amd64
+
+# Defines what container image is used
+[centos:vars]
+source = centos/7/amd64

--- a/lxd-testenv/lxd-remove.yml
+++ b/lxd-testenv/lxd-remove.yml
@@ -1,0 +1,103 @@
+---
+
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html
+
+# Prune container settings after completion of test work
+
+- name: Login to all hosts (in inventory) in order to collect Ansible Facts
+  hosts: all
+  gather_facts: yes
+  become: no
+
+  tasks:
+    - name: Create dynamic host groups based on their OS distribution
+      group_by:
+        key: os_{{ ansible_facts['distribution'] }}
+  tags:
+    # Assumption: We always want to gather facts before beginning work
+    - always
+
+- name: Prune SSH host key entries
+  hosts: all
+  connection: local
+  gather_facts: no
+
+  tasks:
+
+    # Perform this task before shutting down/removing containers
+    # we may not be able to easily obtain the information otherwise
+    # - name: "Remove container hostkeys from known_hosts file on LXD host"
+    #   become: no
+    #   shell: |
+    #     ssh-keygen -R {{ hostvars[inventory_hostname].ansible_default_ipv4.address }}
+    #     ssh-keygen -R {{ inventory_hostname }}
+    #   tags:
+    #     - never
+    #     - remove
+
+    - name: "Remove container hostkeys from known_hosts file on LXD host via IP Address"
+      delegate_to: localhost
+      become: no
+      known_hosts:
+        path: "~/.ssh/known_hosts"
+        name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        state: absent
+      tags:
+        - remove
+
+    - name: "Remove container hostkeys from known_hosts file on LXD host via hostname"
+      delegate_to: localhost
+      become: no
+      known_hosts:
+        path: "~/.ssh/known_hosts"
+        name: "{{ inventory_hostname }}"
+        state: absent
+      tags:
+        - remove
+
+- name: Remove our LXD containers
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+
+    - name: Stop containers
+      lxd_container:
+        name: "{{ item }}"
+        state: stopped
+        timeout: 90
+      with_items:
+        - "{{ groups['centos'] }}"
+        - "{{ groups['ubuntu'] }}"
+      tags:
+        - remove
+
+    - name: Delete containers
+      lxd_container:
+        name: "{{ item }}"
+        state: absent
+        timeout: 90
+      with_items:
+        - "{{ groups['centos'] }}"
+        - "{{ groups['ubuntu'] }}"
+      tags:
+        - remove
+
+    - name: "Remove container entries from hosts file on LXD host"
+      become: yes
+      lineinfile:
+        dest: /etc/hosts
+        regexp: '.*{{ item }}$'
+        state: absent
+      with_items:
+        - "{{ groups['all'] }}"
+      tags:
+        - remove
+
+
+...

--- a/lxd-testenv/lxd-setup-containers.yml
+++ b/lxd-testenv/lxd-setup-containers.yml
@@ -1,0 +1,149 @@
+---
+
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html
+
+- name: Create LXD containers for Ansible test environment
+  hosts: localhost
+  connection: local
+  tasks:
+
+    # TODO: Combine 'when', 'item' and 'with_items' to process groups
+
+    - name: Create containers
+      delegate_to: localhost
+      lxd_container:
+        name: "{{ item }}"
+        state: started
+        source:
+          type: image
+          mode: pull
+          server: https://images.linuxcontainers.org
+          protocol: lxd
+          alias: "{{ hostvars[item]['source'] }}"
+        profiles: ["default"]
+        wait_for_ipv4_addresses: true
+        timeout: 600
+      with_items:
+        - "{{ groups['ubuntu'] }}"
+        - "{{ groups['centos'] }}"
+      tags:
+        - create
+
+- name: Bootstrap LXD containers for Ansible test environment
+  hosts: all
+  connection: local
+  vars:
+    # Configured in hosts file, but specifying here as well for clarity
+    ansible_connection: lxd
+
+  # Python is not present at this point, so we cannot gather facts
+  # https://docs.ansible.com/ansible/latest/modules/raw_module.html
+  gather_facts: false
+  tasks:
+
+    - name: Confirm python is installed in container
+      raw: test -e /usr/bin/python
+      register: python_install_check
+      failed_when: python_install_check.rc not in [0, 1]
+      changed_when: false
+
+    # Triggered when -vvvv is specified
+    # https://docs.ansible.com/ansible/latest/modules/debug_module.html
+    - name: DEBUG | Display all known facts about host
+      debug:
+        var: hostvars[inventory_hostname]
+        verbosity: 4
+
+    # Triggered when -vv is specified
+    - name: DEBUG | Show python check results
+      debug:
+        var: python_install_check.stdout
+        verbosity: 2
+
+    # Only occurs with containers without Python
+    - name: Install Python on Ubuntu containers
+      raw: apt-get update && apt-get install -y python
+      when:
+        - python_install_check.rc == 1
+        - inventory_hostname in groups['ubuntu']
+
+    # Only occurs with containers without Python
+    - name: Install Python on CentOS containers
+      raw: yum install -y python
+      when:
+        - python_install_check.rc == 1
+        - inventory_hostname in groups['centos']
+
+
+- name: Prep containers for management via SSH
+  hosts: all
+  connection: local
+  gather_facts: yes
+  vars:
+    # Configured in hosts file, but specifying here as well for clarity
+    ansible_connection: lxd
+
+  tasks:
+
+    - name: Install required packages
+      package:
+        name:
+          - openssh-server
+          - sudo
+        state: present
+
+    - name: Deploy current user SSH public key to root user in container
+      authorized_key:
+        user: root
+        state: present
+        key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
+
+    - name: Create ansible group
+      group:
+        name: "ansible"
+        state: present
+        system: no
+
+    - name: Create ansible user
+      user:
+        name: "ansible"
+        comment: Service account used by Ansible to configure system
+        group: "ansible"
+        state: present
+        system: no
+
+    - name: Deploy current user SSH public key to ansible user in container
+      authorized_key:
+        user: ansible
+        state: present
+        key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
+
+    - name: "Create ansible sudoers file in container"
+      copy:
+        content: 'ansible ALL=(ALL) NOPASSWD: ALL'
+        dest: /etc/sudoers.d/ansible'
+        owner: root
+        group: root
+        mode: 0440
+
+    - name: Start SSH, set it to start at boot
+      service:
+        name: sshd
+        state: started
+        enabled: yes
+
+    - name: "Update hosts file in container"
+      lineinfile:
+        dest: /etc/hosts
+        regexp: '.*{{ item}}$'
+        line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
+        state: present
+      when: hostvars[item].ansible_default_ipv4.address is defined
+      with_items:
+        - "{{ groups['all'] }}"
+
+...

--- a/lxd-testenv/lxd-setup-host.yml
+++ b/lxd-testenv/lxd-setup-host.yml
@@ -1,0 +1,76 @@
+---
+
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html
+
+# An example for creating Ubuntu containers and installing python in each
+
+- name: Login to all hosts (in inventory) in order to collect Ansible Facts
+  hosts: all
+  gather_facts: yes
+  become: no
+
+  vars:
+    # Configured in hosts file, but specifying here as well for clarity
+    ansible_connection: lxd
+
+  tasks:
+    - name: Create dynamic host groups based on their OS distribution
+      group_by:
+        key: os_{{ ansible_facts['distribution'] }}
+  tags:
+    # Assumption: We always want to gather facts before beginning work
+    - always
+
+
+- name: Update container host
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+
+  vars:
+    ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+
+  tasks:
+
+    # Generate /etc/hosts with Ansible
+    # https://gist.github.com/rothgar/8793800
+    - name: "Update hosts file on LXD host"
+      become: yes
+      lineinfile:
+        dest: /etc/hosts
+        regexp: '.*{{ hostvars[item].inventory_hostname }}$'
+        line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
+        state: present
+      when: hostvars[item].ansible_default_ipv4.address is defined
+      with_items:
+        - "{{ groups['all'] }}"
+
+    # https://stackoverflow.com/questions/30226113/ansible-ssh-prompt-known-hosts-issue
+    - name: Scan each host for its ssh public key
+      become: no
+      shell: |
+        #ssh-keyscan -H {{ hostvars[item].inventory_hostname }},{{ hostvars[item].ansible_default_ipv4.address }}
+        ssh-keyscan {{ hostvars[item].inventory_hostname }},{{ hostvars[item].ansible_default_ipv4.address }}
+      register: ssh_known_host_results
+      changed_when: ssh_known_host_results.rc != 0
+      failed_when: ssh_known_host_results.rc != 0
+      with_items:
+        - "{{ groups['all'] }}"
+
+    # - name: For each host, scan for its ssh public key
+    #   shell: "ssh-keyscan {{ item }},`dig +short {{ item }}`"
+    #   with_items: "{{ groups['all'] }}"
+    #   register: ssh_known_host_results
+    #   ignore_errors: yes
+
+    - name: Add/update the public key in the '{{ ssh_known_hosts_file }}'
+      known_hosts:
+        name: "{{ item.item }}"
+        key: "{{ item.stdout }}"
+        path: "{{ ssh_known_hosts_file }}"
+      with_items: "{{ ssh_known_host_results.results }}"
+


### PR DESCRIPTION
- Create multiple CentOS and Ubuntu test containers
  - installation of sudo, python, openssh packages
  - update of /etc/hosts to reflect all other
    container IPs
  - creation of 'ansible' user account with sudo
    privileges
  - insertion of host SSH pub key in container
    root and ansible user accounts

- Update of LXD host to reflect container details
  - /etc/hosts updated with container IPs
  - known_hosts updated with container host keys

- Tear down containers, changes applied to LXD
  host (/etc/hosts, known_hosts)

- README file with basic coverage of deps