### PR TITLE
Explicitly ask Ansible to create user home dir

### DIFF
--- a/lxd-testenv/lxd-setup-containers.yml
+++ b/lxd-testenv/lxd-setup-containers.yml
@@ -111,6 +111,9 @@
     - name: Create ansible user
       user:
         name: "ansible"
+        # Explicitly specify this in case the default behavior ever changes
+        # Credit: @auadamw
+        create_home: yes
         comment: Service account used by Ansible to configure system
         group: "ansible"
         state: present


### PR DESCRIPTION
Credit goes to @auadamw.

We (re)learned that:

- CentOS defaults to creating the user home directory
- Ubuntu does not 

For better or worse, Ansible mirrors CentOS functionality and creates home directories automatically when setting up a new user account.

This PR explicitly sets the parameter to create the home directory just in case the future default changes, however unlikely it is.