### PR TITLE
Move vars to external file, misc cleanup

### DIFF
--- a/lxd-testenv/README.md
+++ b/lxd-testenv/README.md
@@ -24,7 +24,15 @@ used for accessing containers on the test LXD host system.
 These playbooks require that you first install the LXD daemon and client
 packages. After that, run `sudo lxd init`.
 
-Be sure to use NAT, DHCP and setup a bridge network device (NAT).
+Be sure to use NAT, DHCP and setup a bridge network device (NAT). Containers
+created and attached to this bridge will be reachable by the host (and each
+other), but will not be directly reachable by external systems. You will need
+to setup port forwarding rules *or* setup an external bridge for containers
+to be externally reachable. Additionally, you will need to reconfigure LXD
+to use the new bridge device.
+
+For most (playbook) testing purposes, the NAT bridge will probably be
+sufficient.
 
 **Note:** This held true as of LXD 2.0. I have not tested 2.5+ sufficiently
 to know what additional steps are needed to safely setup LXD for local testing.
@@ -33,8 +41,16 @@ to know what additional steps are needed to safely setup LXD for local testing.
 
 ### Create new test environment
 
+If you wish to setup containers and the host as separate steps (perhaps for
+troubleshooting purposes):
+
 1. `ansible-playbook -i hosts lxd-setup-containers.yml -K`
 1. `ansible-playbook -i hosts lxd-setup-host.yml -K`
+
+Alternatively, you can combine the steps from both playbooks by using the
+provided "wrapper" playbook:
+
+1. `ansible-playbook -i hosts lxd-setup.yml -K`
 
 ### Teardown test environment
 

--- a/lxd-testenv/lxd-remove.yml
+++ b/lxd-testenv/lxd-remove.yml
@@ -13,6 +13,10 @@
   gather_facts: yes
   become: no
 
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
+
   tasks:
     - name: Create dynamic host groups based on their OS distribution
       group_by:
@@ -25,6 +29,10 @@
   hosts: all
   connection: local
   gather_facts: no
+
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
 
   tasks:
 
@@ -63,6 +71,10 @@
   hosts: localhost
   connection: local
   gather_facts: no
+
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
 
   tasks:
 

--- a/lxd-testenv/lxd-setup-containers.yml
+++ b/lxd-testenv/lxd-setup-containers.yml
@@ -9,9 +9,12 @@
 - name: Create LXD containers for Ansible test environment
   hosts: localhost
   connection: local
-  tasks:
 
-    # TODO: Combine 'when', 'item' and 'with_items' to process groups
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
+
+  tasks:
 
     - name: Create containers
       delegate_to: localhost
@@ -39,6 +42,10 @@
   vars:
     # Configured in hosts file, but specifying here as well for clarity
     ansible_connection: lxd
+
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
 
   # Python is not present at this point, so we cannot gather facts
   # https://docs.ansible.com/ansible/latest/modules/raw_module.html
@@ -85,7 +92,14 @@
   gather_facts: yes
   vars:
     # Configured in hosts file, but specifying here as well for clarity
+    # WARNING: Do not specify this for ALL plays, just ones where we
+    # will be directly manipulating containers. Attempts to directly
+    # modify the host with this value defined may (will?) fail.
     ansible_connection: lxd
+
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
 
   tasks:
 
@@ -95,12 +109,6 @@
           - openssh-server
           - sudo
         state: present
-
-    - name: Deploy current user SSH public key to root user in container
-      authorized_key:
-        user: root
-        state: present
-        key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
 
     - name: Create ansible group
       group:
@@ -119,12 +127,6 @@
         state: present
         system: no
 
-    - name: Deploy current user SSH public key to ansible user in container
-      authorized_key:
-        user: ansible
-        state: present
-        key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
-
     - name: "Create ansible sudoers file in container"
       copy:
         content: 'ansible ALL=(ALL) NOPASSWD: ALL'
@@ -132,6 +134,15 @@
         owner: root
         group: root
         mode: 0440
+
+    - name: Deploy current user SSH public key to specific users in container
+      authorized_key:
+        user: "{{ item }}"
+        state: present
+        key: "{{ ssh_public_key_for_containers }}"
+      with_items:
+        - root
+        - ansible
 
     - name: Start SSH, set it to start at boot
       service:
@@ -145,7 +156,9 @@
         regexp: '.*{{ item}}$'
         line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
         state: present
-      when: hostvars[item].ansible_default_ipv4.address is defined
+      when:
+        - hostvars[item].ansible_default_ipv4.address is defined
+        - update_container_hosts_file
       with_items:
         - "{{ groups['all'] }}"
 

--- a/lxd-testenv/lxd-setup-host.yml
+++ b/lxd-testenv/lxd-setup-host.yml
@@ -17,6 +17,10 @@
     # Configured in hosts file, but specifying here as well for clarity
     ansible_connection: lxd
 
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
+
   tasks:
     - name: Create dynamic host groups based on their OS distribution
       group_by:
@@ -31,8 +35,9 @@
   connection: local
   gather_facts: yes
 
-  vars:
-    ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+  # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
+  vars_files:
+    - vars/main.yml
 
   tasks:
 
@@ -45,7 +50,9 @@
         regexp: '.*{{ hostvars[item].inventory_hostname }}$'
         line: "{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}"
         state: present
-      when: hostvars[item].ansible_default_ipv4.address is defined
+      when:
+        - hostvars[item].ansible_default_ipv4.address is defined
+        - update_host_etc_hosts_file
       with_items:
         - "{{ groups['all'] }}"
 
@@ -58,6 +65,9 @@
       register: ssh_known_host_results
       changed_when: ssh_known_host_results.rc != 0
       failed_when: ssh_known_host_results.rc != 0
+      when:
+        - hostvars[item].ansible_default_ipv4.address is defined
+        - update_host_known_hosts_file
       with_items:
         - "{{ groups['all'] }}"
 
@@ -72,5 +82,7 @@
         name: "{{ item.item }}"
         key: "{{ item.stdout }}"
         path: "{{ ssh_known_hosts_file }}"
+      when:
+        - update_host_known_hosts_file
       with_items: "{{ ssh_known_host_results.results }}"
 

--- a/lxd-testenv/vars/main.yml
+++ b/lxd-testenv/vars/main.yml
@@ -1,0 +1,26 @@
+---
+
+# vim: ts=2:sw=2:et:ft=ansible
+# -*- mode: ansible; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=ansible insertSpaces=true tabSize=2
+
+# Should the /etc/hosts file on each container be updated to list all other
+# containers? If this is not enabled, then built-in dnsmasq support will be used
+# to provide name resolution between containers.
+update_container_hosts_file: false
+
+# This key will be pushed from the host to each container that is created
+ssh_public_key_for_containers: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_ed25519.pub') }}"
+
+# By default, update the $HOME/.ssh/known_hosts file on the host with
+# host keys from all containers.
+update_host_known_hosts_file: true
+
+# By default, update the /etc/hosts file on the host (e.g., the system running
+# the LXD containers) to reflect each container name/IP pair
+update_host_etc_hosts_file: true
+
+# Host copy of file. Updated to reflect host keys of all containers.
+ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+
+...


### PR DESCRIPTION
- Update README file
    - illustrate wrapper setup playbook
    - brief mention of NAT bridge vs external bridge

- De-dupe pub key insertion for containers (one task vs two)

- Add control flags for host modifications
    - /etc/hosts
    - $HOME/.ssh/known_hosts

- Move vars to external file (light prep for role creation)