### PR TITLE
Add multiple host group tiers

### DIFF
--- a/lxd-testenv/hosts
+++ b/lxd-testenv/hosts
@@ -27,6 +27,30 @@ ansible-ubuntu-12
 ansible-ubuntu-13
 
 
+[tier1]
+ansible-centos-1
+ansible-ubuntu-11
+
+[tier2]
+ansible-centos-3
+ansible-ubuntu-10
+
+[tier3]
+ansible-centos-4
+ansible-centos-5
+ansible-ubuntu-12
+
+[tier4]
+ansible-centos-2
+ansible-ubuntu-9
+
+[tier5]
+ansible-centos-6
+ansible-centos-7
+ansible-centos-8
+ansible-ubuntu-13
+
+
 [all:vars]
 
 # Everything in this inventory is a LXD container, so make sure Ansible only


### PR DESCRIPTION
Probably a more efficient way to do this, but the goal is to mirror some of the internal tiers that we run our playbooks against.