### PR TITLE
Enforce serial host key insertion

### DIFF
--- a/lxd-testenv/lxd-setup-host.yml
+++ b/lxd-testenv/lxd-setup-host.yml
@@ -35,6 +35,9 @@
   connection: local
   gather_facts: yes
 
+  # Likely needed to avoid race conditions (refs atc0005/ansible-playbooks#11)
+  serial: 1
+
   # TODO: Cleanup, move to defaults/main.yml when migrating to lxd-testenv role
   vars_files:
     - vars/main.yml


### PR DESCRIPTION
This is an attempt to help prevent race conditions as observed
when removing host keys for a batch of systems.

refs #11, #12